### PR TITLE
Added check in RGB branch for Alpha-channel. 

### DIFF
--- a/starnet_v1_TF2.py
+++ b/starnet_v1_TF2.py
@@ -323,6 +323,10 @@ class StarNet():
         if self.mode == 'RGB' and len(image.shape) == 2:
             raise ValueError('You loaded RGB model, but the image is Greyscale!')
         
+        if self.mode == 'RGB' and image.shape[2] == 4:
+            print("Input image has 4 channels. Removing Alpha-Channel")
+            image=image[:,:,[0,1,2]]
+        
         offset = int((self.window_size - self.stride) / 2)
         
         h, w, _ = image.shape


### PR DESCRIPTION
Some software, GIMP in particular, always writes .tiff with a (dummy) alpha-channel, which causes starnet to crash.

I have added a quick check if an RGB image has actually 4 instead of 3 channels. In that case the user is informed and the 4th channel removed.

I have tested it on my data and it works beautifully with gimp 4-channel tiffs afterwards.